### PR TITLE
Fix: Handle null idMal in API response

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -143,6 +143,9 @@ dependencies {
     //AboutLibraries
     implementation(libs.aboutlibraries)
     implementation(libs.aboutlibraries.compose)
+
+    // JUnit for unit testing
+    testImplementation(libs.junit)
 }
 
 aboutLibraries {

--- a/app/src/main/java/pw/janyo/whatanime/model/Animation.kt
+++ b/app/src/main/java/pw/janyo/whatanime/model/Animation.kt
@@ -33,7 +33,7 @@ data class SearchAnimeResultItem(
 
 data class SearchAniListResult(
     val id: Long = 0,
-    val idMal: Long = 0,
+    val idMal: Long? = 0,
     val title: AniListTitleResult,
     @Json(name = "isAdult")
     val adult: Boolean = false,

--- a/app/src/main/java/pw/janyo/whatanime/ui/activity/MainActivity.kt
+++ b/app/src/main/java/pw/janyo/whatanime/ui/activity/MainActivity.kt
@@ -626,7 +626,7 @@ fun BuildResultItem(
                         Column {
                             BuildText("${(result.from.toLong() * 1000).formatTime()} ~ ${(result.to.toLong() * 1000).formatTime()}")
                             BuildText("${result.aniList.id}")
-                            BuildText("${result.aniList.idMal}")
+                            BuildText(result.aniList.idMal?.toString() ?: "N/A")
                             BuildText(
                                 text = "${DecimalFormat("#.000").format(result.similarity * 100)}%",
                                 fontWeight = FontWeight.Bold,

--- a/app/src/test/java/pw/janyo/whatanime/model/AnimationTest.kt
+++ b/app/src/test/java/pw/janyo/whatanime/model/AnimationTest.kt
@@ -1,0 +1,62 @@
+package pw.janyo.whatanime.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AnimationTest {
+
+    @Test
+    fun testParseSearchAnimeResult_withNullIdMal() {
+        val jsonString = """
+            {
+                "frameCount": 745506,
+                "error": "",
+                "result": [
+                    {
+                        "anilist": {
+                            "id": 99939,
+                            "idMal": null, 
+                            "title": {
+                                "native": "ネコぱらOVA",
+                                "romaji": "Nekopara OVA",
+                                "english": null
+                            },
+                            "synonyms": ["Neko Para OVA"],
+                            "isAdult": false
+                        },
+                        "filename": "Nekopara - OVA (BD 1280x720 x264 AAC).mp4",
+                        "episode": null,
+                        "from": 97.75,
+                        "to": 98.92,
+                        "similarity": 0.9440424588727485,
+                        "video": "https://api.trace.moe/video/99939/Nekopara%20-%20OVA%20(BD%201280x720%20x264%20AAC).mp4?t=98.335&now=1653892514&token=xxxxxxxxxxxxxx",
+                        "image": "https://api.trace.moe/image/99939/Nekopara%20-%20OVA%20(BD%201280x720%20x264%20AAC).mp4.jpg?t=98.335&now=1653892514&token=xxxxxxxxxxxxxx"
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        var parsedResult: SearchAnimeResult? = null
+        var exception: Exception? = null
+        
+        try {
+            parsedResult = searchAnimeResultAdapter.fromJson(jsonString)
+        } catch (e: Exception) {
+            exception = e
+        }
+
+        assertNull("Parsing should not throw an exception", exception)
+        assertNotNull("Parsed result should not be null", parsedResult)
+        assertEquals("Result list should contain one item", 1, parsedResult?.result?.size)
+        
+        val firstResultItem = parsedResult?.result?.get(0)
+        assertNotNull("First result item should not be null", firstResultItem)
+        
+        val aniList = firstResultItem?.aniList
+        assertNotNull("AniList object should not be null", aniList)
+        assertNull("idMal should be null", aniList?.idMal)
+        assertEquals("AniList ID should be 99939L", 99939L, aniList?.id) // Verify other fields are parsed
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ moshi = "1.15.2"
 mmkv = "2.1.0"
 composePreference = "1.1.1"
 media3Exoplayer = "1.6.1"
+junit = "4.13.2"
 
 [libraries]
 gradle = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
@@ -74,6 +75,8 @@ media3-ui = { group = "androidx.media3", name = "media3-ui", version.ref = "medi
 
 aboutlibraries = { group = "com.mikepenz", name = "aboutlibraries-core", version.ref = "aboutlibrariesDependencies" }
 aboutlibraries-compose = { group = "com.mikepenz", name = "aboutlibraries-compose-m3", version.ref = "aboutlibrariesDependencies" }
+
+junit = { group = "junit", name = "junit", version.ref = "junit" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
The API sometimes returns a null value for `idMal` in the anilist data, which caused a Moshi parsing exception because the `idMal` field was defined as a non-nullable Long.

This commit addresses the issue by:
1. Modifying the `idMal` field in the `SearchAniListResult` data class to be nullable (`Long?`).
2. Updating the UI in `MainActivity.kt` to display "N/A" when `idMal` is null, instead of the string "null".
3. Adding a unit test (`AnimationTest.kt`) to specifically verify that JSON responses with `idMal = null` are parsed correctly without exceptions and that the `idMal` field is properly set to null in the resulting object.