### PR TITLE
Fix: Handle various data types for episode field in API response

### DIFF
--- a/composeApp/src/commonMain/kotlin/pw/janyo/whatanime/model/Animation.kt
+++ b/composeApp/src/commonMain/kotlin/pw/janyo/whatanime/model/Animation.kt
@@ -2,6 +2,7 @@ package pw.janyo.whatanime.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 
 @Serializable
 data class SearchAnimeResult(
@@ -16,7 +17,7 @@ data class SearchAnimeResultItem(
     val aniList: SearchAniListResult,
     @SerialName("filename")
     val fileName: String,
-    val episode: String? = null,
+    val episode: JsonElement? = null,
     val from: Double = 0.0,
     val to: Double = 0.0,
     val similarity: Double = 0.0,

--- a/composeApp/src/commonMain/kotlin/pw/janyo/whatanime/repository/AnimationRepository.kt
+++ b/composeApp/src/commonMain/kotlin/pw/janyo/whatanime/repository/AnimationRepository.kt
@@ -22,6 +22,7 @@ import pw.janyo.whatanime.db.service.HistoryService
 import pw.janyo.whatanime.model.AnimationHistory
 import pw.janyo.whatanime.model.SearchAnimeResult
 import pw.janyo.whatanime.model.SearchQuota
+import pw.janyo.whatanime.utils.formatEpisode
 import pw.janyo.whatanime.utils.isOnline
 import pw.janyo.whatanime.utils.md5
 import whatanime.composeapp.generated.resources.Res
@@ -117,7 +118,7 @@ class AnimationRepository : KoinComponent {
                     val result = searchAnimeResult.result[0]
                     this.title = result.aniList.title.native ?: ""
                     this.anilistId = result.aniList.id ?: 0
-                    this.episode = ""
+                    this.episode = formatEpisode(result.episode) ?: ""
                     this.similarity = result.similarity
                 } else {
                     this.title = getString(Res.string.hint_no_result)

--- a/composeApp/src/commonMain/kotlin/pw/janyo/whatanime/ui/components/SearchResultItem.kt
+++ b/composeApp/src/commonMain/kotlin/pw/janyo/whatanime/ui/components/SearchResultItem.kt
@@ -31,6 +31,7 @@ import org.jetbrains.compose.resources.stringResource
 import pw.janyo.whatanime.Configure
 import pw.janyo.whatanime.model.SearchAnimeResultItem
 import pw.janyo.whatanime.utils.formatDecimal
+import pw.janyo.whatanime.utils.formatEpisode
 import pw.janyo.whatanime.utils.formatTime
 import whatanime.composeapp.generated.resources.Res
 import whatanime.composeapp.generated.resources.detail_hint_ani_list_id
@@ -70,11 +71,11 @@ fun SearchResultItem(
                         fontWeight = FontWeight.Bold,
                         fontSize = 14.sp
                     )
-                    result.episode?.let {
+                    formatEpisode(result.episode)?.let { episodeString ->
                         BuildText(
                             text = stringResource(
                                 Res.string.detail_hint_episode,
-                                it
+                                episodeString
                             ),
                             fontSize = 14.sp
                         )

--- a/composeApp/src/commonMain/kotlin/pw/janyo/whatanime/utils/StringUtil.kt
+++ b/composeApp/src/commonMain/kotlin/pw/janyo/whatanime/utils/StringUtil.kt
@@ -8,3 +8,27 @@ fun formatDecimal(value: Double, digits: Int = 1): String {
     val rounded = (value * multiplier).roundToLong() / multiplier
     return rounded.toString()
 }
+
+fun formatEpisode(episodeElement: kotlinx.serialization.json.JsonElement?): String? {
+    return when (episodeElement) {
+        null, is kotlinx.serialization.json.JsonNull -> null
+        is kotlinx.serialization.json.JsonPrimitive -> {
+            if (episodeElement.isString) {
+                episodeElement.content
+            } else {
+                // For numbers or booleans, content gives their string representation
+                episodeElement.content
+            }
+        }
+        is kotlinx.serialization.json.JsonArray -> {
+            episodeElement.joinToString(", ") {
+                if (it is kotlinx.serialization.json.JsonPrimitive) {
+                    it.content
+                } else {
+                    "" // Or some other placeholder for unexpected array elements
+                }
+            }.ifEmpty { null }
+        }
+        else -> null // Or a placeholder like "Unknown"
+    }
+}


### PR DESCRIPTION
- Modified `SearchAnimeResultItem.episode` from `String?` to `JsonElement?` to allow deserialization of number, float, string, array, or null values.
- Added `formatEpisode` utility function to convert `JsonElement?` to a displayable string, handling different JSON types.
- Updated `SearchResultItem.kt` to use `formatEpisode` for displaying episode information.
- Updated `AnimationRepository.kt` to use `formatEpisode` when saving episode data to history, ensuring a consistent string representation.